### PR TITLE
Fix ru gen

### DIFF
--- a/ru/read_until_client.py
+++ b/ru/read_until_client.py
@@ -64,7 +64,9 @@ class RUClient(ReadUntilClient):
         actions = list()
         for channel, read_number, read_id in reads:
             actions.append(
-                self._generate_action(channel, read_number, "unblock", duration=duration)
+                self._generate_action(
+                    channel, read_number, "unblock", duration=duration
+                )
             )
             self.unblock_logger.debug(read_id)
         self.action_queue.put(actions)

--- a/ru/read_until_client.py
+++ b/ru/read_until_client.py
@@ -64,7 +64,7 @@ class RUClient(ReadUntilClient):
         actions = list()
         for channel, read_number, read_id in reads:
             actions.append(
-                self._generate_action(channel, read, "unblock", duration=duration)
+                self._generate_action(channel, read_number, "unblock", duration=duration)
             )
             self.unblock_logger.debug(read_id)
         self.action_queue.put(actions)

--- a/ru/read_until_client.py
+++ b/ru/read_until_client.py
@@ -52,6 +52,23 @@ class RUClient(ReadUntilClient):
         ):
             time.sleep(1)
 
+    def unblock_read_batch(self, reads, duration=0.1):
+        """Request for a bunch of reads be unblocked.
+        reads is expected to be a list of (channel, ReadData.number)
+        :param reads: List of (channel, read_number, read_id)
+        :type reads: list(tuple)
+        :param duration: time in seconds to apply unblock voltage.
+        :type duration: float
+        :returns: None
+        """
+        actions = list()
+        for channel, read_number, read_id in reads:
+            actions.append(
+                self._generate_action(channel, read, "unblock", duration=duration)
+            )
+            self.unblock_logger.debug(read_id)
+        self.action_queue.put(actions)
+
     def unblock_read(self, read_channel, read_number, duration=0.1, read_id=None):
         super().unblock_read(
             read_channel=read_channel,

--- a/ru/ru_gen.py
+++ b/ru/ru_gen.py
@@ -285,7 +285,6 @@ def simple_analysis(
             if conditions[run_info[channel]].control:
                 mode = "control"
                 log_decision()
-                # client.stop_receiving_read(channel, read_number)
                 stop_receiving_action_list.append((channel, read_number))
                 continue
 
@@ -493,7 +492,6 @@ def run(parser, args):
     read_until_client.run(
         first_channel=args.channels[0],
         last_channel=args.channels[-1],
-        # action_throttle=args.action_throttle,
     )
 
     try:

--- a/ru/ru_gen.py
+++ b/ru/ru_gen.py
@@ -475,7 +475,7 @@ def run(parser, args):
         mk_host=position.host,
         mk_port=position.description.rpc_ports.insecure,
         filter_strands=True,
-        cache_size=args.cache_size,
+        #cache_size=args.cache_size,
         cache_type=AccumulatingCache,
     )
 

--- a/ru/ru_gen.py
+++ b/ru/ru_gen.py
@@ -509,7 +509,7 @@ def run(parser, args):
     read_until_client.run(
         first_channel=args.channels[0],
         last_channel=args.channels[-1],
-        action_throttle=args.action_throttle,
+        #action_throttle=args.action_throttle,
     )
 
     try:

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -58,7 +58,8 @@ def simple_analysis(
 
         r = 0
         t0 = timer()
-        unblock_batch_action_list=[]
+        unblock_batch_action_list = []
+        stop_receiving_action_list = []
         for r, (channel, read) in enumerate(
             client.get_read_chunks(
                 batch_size=batch_size,
@@ -66,15 +67,15 @@ def simple_analysis(
             ),
             start=1,
         ):
-            #Adding the channel and read.number to a list for a later batched unblock.
-            unblock_batch_action_list.append((channel,read.number))
+            # Adding the channel and read.number to a list for a later batched unblock.
+            unblock_batch_action_list.append((channel, read.number, read_id))
+            stop_receiving_action_list.append((channel, read.number))
 
-
-        if len(unblock_batch_action_list)>0:
+        if len(unblock_batch_action_list) > 0:
             client.unblock_read_batch(
                 unblock_batch_action_list, duration=unblock_duration
             )
-            client.stop_receiving_batch(unblock_batch_action_list)
+            client.stop_receiving_batch(stop_receiving_action_list)
 
         t1 = timer()
         if r:
@@ -130,15 +131,14 @@ def run(parser, args):
         mk_host=position.host,
         mk_port=position.description.rpc_ports.insecure,
         filter_strands=True,
-        #cache_size=args.cache_size,
+        # cache_size=args.cache_size,
         cache_type=AccumulatingCache,
     )
-
 
     read_until_client.run(
         first_channel=args.channels[0],
         last_channel=args.channels[-1],
-        #action_throttle=args.action_throttle,
+        # action_throttle=args.action_throttle,
     )
 
     try:

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -26,7 +26,7 @@ _cli = BASE_ARGS
 
 
 def simple_analysis(
-    client, duration, batch_size=512, throttle=0.1, unblock_duration=0.1
+    client, duration, batch_size=512, throttle=0.4, unblock_duration=0.1
 ):
     """Analysis function
 
@@ -58,7 +58,7 @@ def simple_analysis(
 
         r = 0
         t0 = timer()
-        batch_action=[]
+        unblock_batch_action_list=[]
         for r, (channel, read) in enumerate(
             client.get_read_chunks(
                 batch_size=batch_size,
@@ -66,15 +66,14 @@ def simple_analysis(
             ),
             start=1,
         ):
-            # pass
-            batch_action.append((channel,read.number))
-            #client.unblock_read(
-            #    channel, read.number, read_id=read.id, duration=unblock_duration
-            #)
-            #client.stop_receiving_read(channel, read.number)
+            #Adding the channel and read.number to a list for a later batched unblock.
+            unblock_batch_action_list.append((channel,read.number))
 
-        if len(batch_action)>0:
-            client.unblock_read_batch(batch_action)
+
+        if len(unblock_batch_action_list)>0:
+            client.unblock_read_batch(
+                unblock_batch_action_list, duration=unblock_duration
+            )
             client.stop_receiving_batch(batch_action)
 
         t1 = timer()

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -121,7 +121,6 @@ def run(parser, args):
 
     # Start by logging sys.argv and the parameters used
     logger = logging.getLogger("Manager")
-    # logger = setup_logger(__name__, args.log_format, log_file=args.log_file, level=logging.INFO)
     logger.info(" ".join(sys.argv))
     print_args(args, logger=logger)
 
@@ -131,14 +130,12 @@ def run(parser, args):
         mk_host=position.host,
         mk_port=position.description.rpc_ports.insecure,
         filter_strands=True,
-        # cache_size=args.cache_size,
         cache_type=AccumulatingCache,
     )
 
     read_until_client.run(
         first_channel=args.channels[0],
         last_channel=args.channels[-1],
-        # action_throttle=args.action_throttle,
     )
 
     try:

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -68,7 +68,7 @@ def simple_analysis(
             start=1,
         ):
             # Adding the channel and read.number to a list for a later batched unblock.
-            unblock_batch_action_list.append((channel, read.number, read_id))
+            unblock_batch_action_list.append((channel, read.number, read.read_id))
             stop_receiving_action_list.append((channel, read.number))
 
         if len(unblock_batch_action_list) > 0:

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -68,7 +68,7 @@ def simple_analysis(
             start=1,
         ):
             # Adding the channel and read.number to a list for a later batched unblock.
-            unblock_batch_action_list.append((channel, read.number, read.read_id))
+            unblock_batch_action_list.append((channel, read.number, read.id))
             stop_receiving_action_list.append((channel, read.number))
 
         if len(unblock_batch_action_list) > 0:

--- a/ru/unblock_all.py
+++ b/ru/unblock_all.py
@@ -74,7 +74,7 @@ def simple_analysis(
             client.unblock_read_batch(
                 unblock_batch_action_list, duration=unblock_duration
             )
-            client.stop_receiving_batch(batch_action)
+            client.stop_receiving_batch(unblock_batch_action_list)
 
         t1 = timer()
         if r:


### PR DESCRIPTION
This code updates unblock all to make it work with batches of reads. It also updates ru_gen to use read batches. This is done by changing the logic of the decision dict to add objects to a list - either for unblock or for stop receiving. At the end of each loop through the code, lists are checked to see if they have actions and - if they do - the batch unblock or batch stop receiving commands are used.