### PR TITLE
update address specification and port for RUClient

### DIFF
--- a/ru/ru_gen_boss_runs.py
+++ b/ru/ru_gen_boss_runs.py
@@ -166,7 +166,7 @@ def decision_boss_runs(
     write_out_channels_toml(conditions, run_info, client)
 
     caller = Caller(
-        address="{}:{}".format(caller_kwargs["host"], caller_kwargs["port"]),
+        address="{}/{}".format(caller_kwargs["host"], caller_kwargs["port"]),
         config=caller_kwargs["config_name"],
     )
     # What if there is no reference or an empty MMI
@@ -510,7 +510,7 @@ def run(parser, args):
 
     read_until_client = RUClient(
         mk_host=position.host,
-        mk_port=position.description.rpc_ports.insecure,
+        mk_port=position.description.rpc_ports.secure,
         filter_strands=True,
         cache_type=AccumulatingCache,
     )


### PR DESCRIPTION
I think these are necessary to work with the updated port situation of minknow >=5 and guppy >=6, as discussed on slack. Thanks!