### PR TITLE
Add an odd_even field on readfish barcode_targets

### DIFF
--- a/ru/_version.py
+++ b/ru/_version.py
@@ -1,4 +1,4 @@
 """version.py
 Version of the read until software
 """
-__version__ = "0.0.11a2"
+__version__ = "0.0.11a3"

--- a/ru/basecall.py
+++ b/ru/basecall.py
@@ -75,7 +75,7 @@ class GuppyCaller(PyGuppyClient):
             daq_values = DefaultDAQValues()
 
         for channel, read in reads:
-            read_id = f"RU-{read.id}" #we do not modify read.id itself as this can result in persistence after this function finishes
+            read_id = f"RU-{read.id}"  # we do not modify read.id itself as this can result in persistence after this function finishes
             hold[read_id] = (channel, read.number)
             t0 = time.time()
             success = self.pass_read(

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -539,7 +539,7 @@ def run(parser, args):
     mapper = CustomMapper(reference)
     logger.info("Mapper initialised")
 
-    position = get_device(args.device, host=args.host)
+    position = get_device(args.device, host=args.host, port=args.port)
 
     read_until_client = RUClient(
         mk_host=position.host,

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -106,6 +106,14 @@ _cli = BASE_ARGS + (
             default=None,
         ),
     ),
+    (
+        "--odd-even",
+        dict(
+            metavar="ODD_EVEN",
+            default=None,
+            help="Experimental - applies control to all ODD numbered channels, with readfish operating on EVEN numbered channels.",
+        )
+    )
 )
 
 
@@ -269,11 +277,14 @@ def simple_analysis(
 
         barcode_counter = Counter()
         if live_toml_path.is_file():
+            # Check if we have odd_even set so we keep it if we reload the toml file
+            odd_even = getattr(conditions["unclassified"], "odd_even", False)
             # Reload the TOML config from the *_live file
             conditions, new_reference, _ = get_barcoded_run_info(
                 live_toml_path,
                 flowcell_size,
                 validate=False,
+                odd_even=odd_even
             )
 
             # Check the reference path if different from the loaded mapper
@@ -530,7 +541,7 @@ def run(parser, args):
     # Parse configuration TOML
     # TODO: num_channels is not configurable here, should be inferred from client
     conditions, reference, caller_kwargs = get_barcoded_run_info(
-        args.toml, validate=False
+        args.toml, validate=False, odd_even=args.odd_even
     )
     live_toml = Path("{}_live".format(args.toml))
 

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -111,9 +111,9 @@ _cli = BASE_ARGS + (
         dict(
             default=False,
             help="Experimental - applies control to all ODD numbered channels, with readfish operating on EVEN numbered channels.",
-            action="store_true"
-        )
-    )
+            action="store_true",
+        ),
+    ),
 )
 
 
@@ -281,10 +281,7 @@ def simple_analysis(
             odd_even = getattr(conditions["unclassified"], "odd_even", False)
             # Reload the TOML config from the *_live file
             conditions, new_reference, _ = get_barcoded_run_info(
-                live_toml_path,
-                flowcell_size,
-                validate=False,
-                odd_even=odd_even
+                live_toml_path, flowcell_size, validate=False, odd_even=odd_even
             )
 
             # Check the reference path if different from the loaded mapper

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -370,6 +370,14 @@ def simple_analysis(
                 stop_receiving_action_list.append((channel, read_number))
                 continue
 
+            # check if odd even is set on the condition
+            if condition.odd_even:
+                # 'tis an odd channel, so let's NOT yeet that read
+                if channel % 2:
+                    mode = "control"
+                    log_decision()
+                    stop_receiving_action_list.append((channel, read_number))
+                    continue
             # This is an analysis channel
             # Below minimum chunks
             if tracker[channel][read_number] <= condition.min_chunks:

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -109,7 +109,6 @@ _cli = BASE_ARGS + (
     (
         "--odd-even",
         dict(
-            default=False,
             help="Experimental - applies control to all ODD numbered channels, with readfish operating on EVEN numbered channels.",
             action="store_true",
         ),
@@ -372,7 +371,7 @@ def simple_analysis(
             )
 
             # Control channels
-            # If the condtion is control or odd_even is true and it's an even channel
+            # If the condtion is control or odd_even is true and it's an odd channel
             if condition.control or (odd_even and channel % 2):
                 mode = "control"
                 log_decision()

--- a/ru/ru_barcode_targets.py
+++ b/ru/ru_barcode_targets.py
@@ -109,9 +109,9 @@ _cli = BASE_ARGS + (
     (
         "--odd-even",
         dict(
-            metavar="ODD_EVEN",
-            default=None,
+            default=False,
             help="Experimental - applies control to all ODD numbered channels, with readfish operating on EVEN numbered channels.",
+            action="store_true"
         )
     )
 )

--- a/ru/static/barcode.schema.json
+++ b/ru/static/barcode.schema.json
@@ -38,6 +38,9 @@
             "properties": {
                 "reference": {
                     "type": "string"
+                },
+                "odd_even": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false,

--- a/ru/static/barcode.schema.json
+++ b/ru/static/barcode.schema.json
@@ -38,9 +38,6 @@
             "properties": {
                 "reference": {
                     "type": "string"
-                },
-                "odd_even": {
-                    "type": "boolean"
                 }
             },
             "additionalProperties": false,

--- a/ru/utils.py
+++ b/ru/utils.py
@@ -744,7 +744,9 @@ def get_barcode_kits(address, timeout=10000):
     return res
 
 
-def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True, odd_even: bool = False):
+def get_barcoded_run_info(
+    toml_filepath, num_channels=512, validate=True, odd_even: bool = False
+):
     """Convert a TOML representation of a ReadFish experiment to conditions that
     can be used used by the analysis function
 

--- a/ru/utils.py
+++ b/ru/utils.py
@@ -481,7 +481,8 @@ def load_config_toml(filepath, validate=True):
     # TODO: Re-evaluate the existence... of tomls
 
     toml_dict = {}
-
+    # Loop - if we try to load the toml whilst it is being written to it my be corrupted 
+    # try again until a successful read
     while not toml_dict:
         # Load TOML to dict
         try:
@@ -779,6 +780,14 @@ def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
     toml_dict = load_config_toml(toml_filepath, validate=validate)
     caller_settings = toml_dict.get("caller_settings", {})
 
+    # Check if odd/even field is present in toml conditions
+    odd_even = toml_dict["conditions"].get("odd_even", False)
+    # Add this field to each condition, if it's True
+    if odd_even:
+        for k, v in toml_dict["conditions"].items():
+            if isinstance(v, dict):
+               v["odd_even"] = odd_even
+               
     if caller_settings["host"].startswith("ipc"):
         guppy_address = "{}/{}".format(caller_settings["host"], caller_settings["port"])
     else:

--- a/ru/utils.py
+++ b/ru/utils.py
@@ -744,7 +744,7 @@ def get_barcode_kits(address, timeout=10000):
     return res
 
 
-def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
+def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True, odd_even: bool = False):
     """Convert a TOML representation of a ReadFish experiment to conditions that
     can be used used by the analysis function
 
@@ -765,6 +765,8 @@ def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
         PromethION
     validate : bool
         Validate TOML file
+    odd_even: bool
+        Whether to treat odd channels as control in an experiment
 
     Returns
     -------
@@ -780,8 +782,6 @@ def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
     toml_dict = load_config_toml(toml_filepath, validate=validate)
     caller_settings = toml_dict.get("caller_settings", {})
 
-    # Check if odd/even field is present in toml conditions
-    odd_even = toml_dict["conditions"].get("odd_even", False)
     # Add this field to each condition, if it's True
     if odd_even:
         for k, v in toml_dict["conditions"].items():

--- a/ru/utils.py
+++ b/ru/utils.py
@@ -481,7 +481,7 @@ def load_config_toml(filepath, validate=True):
     # TODO: Re-evaluate the existence... of tomls
 
     toml_dict = {}
-    # Loop - if we try to load the toml whilst it is being written to it my be corrupted 
+    # Loop - if we try to load the toml whilst it is being written to it my be corrupted
     # try again until a successful read
     while not toml_dict:
         # Load TOML to dict
@@ -786,12 +786,12 @@ def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
     if odd_even:
         for k, v in toml_dict["conditions"].items():
             if isinstance(v, dict):
-               v["odd_even"] = odd_even
-               
+                v["odd_even"] = odd_even
+
     if caller_settings["host"].startswith("ipc"):
         guppy_address = "{}/{}".format(caller_settings["host"], caller_settings["port"])
     else:
-        guppy_address="{}:{}".format(caller_settings["host"], caller_settings["port"])
+        guppy_address = "{}:{}".format(caller_settings["host"], caller_settings["port"])
 
     # Get barcodes, going to do some checks here
     barcode_kits = get_barcode_kits(guppy_address)

--- a/ru/utils.py
+++ b/ru/utils.py
@@ -744,9 +744,7 @@ def get_barcode_kits(address, timeout=10000):
     return res
 
 
-def get_barcoded_run_info(
-    toml_filepath, num_channels=512, validate=True, odd_even: bool = False
-):
+def get_barcoded_run_info(toml_filepath, num_channels=512, validate=True):
     """Convert a TOML representation of a ReadFish experiment to conditions that
     can be used used by the analysis function
 
@@ -767,8 +765,6 @@ def get_barcoded_run_info(
         PromethION
     validate : bool
         Validate TOML file
-    odd_even: bool
-        Whether to treat odd channels as control in an experiment
 
     Returns
     -------
@@ -783,12 +779,6 @@ def get_barcoded_run_info(
     pattern = re.compile(r"^(barcode\d{2,}|unclassified|classified)$")
     toml_dict = load_config_toml(toml_filepath, validate=validate)
     caller_settings = toml_dict.get("caller_settings", {})
-
-    # Add this field to each condition, if it's True
-    if odd_even:
-        for k, v in toml_dict["conditions"].items():
-            if isinstance(v, dict):
-                v["odd_even"] = odd_even
 
     if caller_settings["host"].startswith("ipc"):
         guppy_address = "{}/{}".format(caller_settings["host"], caller_settings["port"])


### PR DESCRIPTION
Treat read in odd channels as control reads
Validate a condition named odd_even in the TOML
Address #216 - DO NOT MERGE PLEASE until I have tested it