### PR TITLE
add dynamic reloading of mapping index 

### DIFF
--- a/ru/_version.py
+++ b/ru/_version.py
@@ -1,4 +1,4 @@
 """version.py
 Version of the read until software
 """
-__version__ = "0.0.9a3"
+__version__ = "0.0.9a4"

--- a/ru/read_until_client.py
+++ b/ru/read_until_client.py
@@ -11,7 +11,17 @@ from pathlib import Path
 from threading import RLock
 
 from minknow_api.acquisition_pb2 import MinknowStatus
+from minknow_api import protocol_service
 from read_until import ReadUntilClient
+
+from ru.utils import setup_logger
+from grpc import RpcError
+
+log = setup_logger(
+    __name__,
+    level=logging.INFO,
+    log_format="%(asctime)s %(name)s %(message)s",
+)
 
 
 class RUClient(ReadUntilClient):
@@ -19,6 +29,9 @@ class RUClient(ReadUntilClient):
         super().__init__(*args, **kwargs)
 
         self.logger.disabled = True
+        self.current_phase = self.connection.protocol.get_current_protocol_run().phase
+        self.phase_errors = 0
+        self.max_phase_errors = 1
 
         # We always want one_chunk to be False
         self.one_chunk = False

--- a/ru/ru_gen_boss_runs.py
+++ b/ru/ru_gen_boss_runs.py
@@ -306,8 +306,13 @@ def decision_boss_runs(
             live_toml_path.unlink()
     write_out_channels_toml(conditions, run_info, client)
 
+    if caller_kwargs["host"].startswith("ipc"):
+        guppy_address = "{}/{}".format(caller_kwargs["host"], caller_kwargs["port"])
+    else:
+        guppy_address = "{}:{}".format(caller_kwargs["host"], caller_kwargs["port"])
+
     caller = Caller(
-        address="{}/{}".format(caller_kwargs["host"], caller_kwargs["port"]),
+        address=guppy_address,
         config=caller_kwargs["config_name"],
     )
     # What if there is no reference or an empty MMI
@@ -648,7 +653,7 @@ def run(parser, args):
     mapper = CustomMapper(reference)
     logger.info("Mapper initialised")
 
-    position = get_device(args.device, host=args.host)
+    position = get_device(args.device, host=args.host, port=args.port)
 
     read_until_client = RUClient(
         mk_host=position.host,

--- a/ru/ru_gen_boss_runs.py
+++ b/ru/ru_gen_boss_runs.py
@@ -361,6 +361,9 @@ def decision_boss_runs(
     strand_converter_br, mask_path, contigs_path, masks = init_BR_bits(conditions)
 
     while client.is_running:
+        if not client.is_phase_sequencing:
+            time.sleep(5)
+            continue
         # todo reverse engineer from channels.toml
         if live_toml_path.is_file():
             # Reload the TOML config from the *_live file

--- a/ru/ru_gen_boss_runs.py
+++ b/ru/ru_gen_boss_runs.py
@@ -165,6 +165,30 @@ def reload_mapper(contigs_path, mapper, logger):
 
 
 
+def check_names(masks, mapper, logger):
+    """
+    Check that the names of masks and sequences in the mapper are the same.
+
+    Parameters
+    ----------
+    mapper: mappy.Aligner
+        mapper object that gets replaced with new index
+    masks: dict
+        dict of {contig name: mask array}
+
+    Returns
+    -------
+
+    """
+    mask_names = sorted(list(masks.keys()))
+    contig_names = sorted(list(mapper.seq_names))
+    same_names = mask_names == contig_names
+    if not same_names:
+        logger.error(f"Error loading masks and contigs: discrepancy in names \n {mask_names} \n {contig_names}")
+
+
+
+
 def write_out_channels_toml(conditions, run_info, client):
     """
     Write out the channels toml file
@@ -361,6 +385,7 @@ def decision_boss_runs(
         # BR: load updated decision masks and contigs
         masks = reload_masks(mask_path=mask_path, masks=masks, logger=logger)
         mapper = reload_mapper(contigs_path=contigs_path, mapper=mapper, logger=logger)
+        check_names(masks=masks, mapper=mapper, logger=logger)
 
 
         for read_info, read_id, seq_len, mappings in mapper.map_reads_2(

--- a/ru/ru_gen_boss_runs.py
+++ b/ru/ru_gen_boss_runs.py
@@ -31,6 +31,7 @@ from ru.utils import (
 )
 from ru.utils import send_message, Severity, get_device, DecisionTracker
 
+print("v0.0.3_BR")
 
 _help = "Run dynamic selective sequencing."
 _cli = BASE_ARGS + (


### PR DESCRIPTION
Hi all,
As just discussed I was working on dynamically reloading mm2 mapping indices, which we need to map to the constantly updated assemblies. I added this basically in the same way as the reloading of target masks is done: whenever we generate a new assembly (or new masks), we create an empty marker-file called `contigs.updated` (as previously `masks.updated`). readfish checks if this marker-file is present and if so, will reload the files and delete the marker-file. In the case of reloading an index, it creates a new instances of your `CustomMapper()` and replaces the previous `mapper` object with the new one. 
The changes are all in `ru/ru_gen_boss_runs.py`. Hope there won't be any conflicts with the changes you mentioned about not unblocking during mux scan phases?
Thanks,
Lukas