### PR TITLE
Refine scope of documentation deployment on closed PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,11 +2,12 @@ name: CI
 
 on:
   push:
-    paths-ignore:
-      - 'README.md'
   schedule:
     - cron:  '0 0 * * SUN'
   pull_request:
+    branches:
+      - refactor
+      - main
     types:
       - closed
   workflow_dispatch:


### PR DESCRIPTION
Currently the docs are deployed when any PR is closed. We definitely only want to do this when the docs are successfully merged into refactor, or main.

This change will mean that the PR has to be merged into refactor or main to trigger the CI workflow.

Also removes the `paths-ignore` field, meaning that CI is run on README.md changes solo.

Closes #264 
Closes #263 