### PR TITLE
CI QOL update, including Publish package to PyPI on tag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: html-docs
-          path: _build/html/
+          path: docs/_build/html/
           if-no-files-found: error
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,5 +115,5 @@ jobs:
     - name: Build package
       run: python -m hatchling build
     - name: Publish package distributions to PyPI
-      if: 'startsWith(github.ref, "refs/tags/")'
+      if: startsWith(github.ref, 'refs/tags/')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,3 +91,29 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/
+
+  build_and_deploy:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: tests
+    environment:
+      name: pypi
+      url: https://pypi.org/p/readfish
+    permissions:
+      id-token: write 
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install hatchling
+    - name: Build package
+      run: python -m hatchling build
+    - name: Publish package distributions to PyPI
+      if: 'startsWith(github.ref, "refs/tags/")'
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           python -m site
           python -m pip install -U pip setuptools wheel
           python -m pip install -e ".[tests]"
-          coverage -m pytest
+          coverage run -m pytest
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,12 +47,12 @@ jobs:
           python -m site
           python -m pip install -U pip setuptools wheel
           python -m pip install -e ".[tests]"
-          coverage run -m pytest
+          coverage run -pm pytest
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:
           name: coverage-data
-          path: .coverage.*
+          path: .coverage*
           if-no-files-found: ignore
 
   coverage:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python -m pip install coverage[toml]
           python -m coverage combine
-          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+          python -m coverage report --skip-empty --fail-under=72 --format=markdown >> $GITHUB_STEP_SUMMARY
 
   build-package:
     name: Build python package

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,11 +103,11 @@ jobs:
       id-token: write
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.10
+        python-version: ${{env.PYTHON_LATEST}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version-file: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ env.PYTHON_LATEST }}
           cache: pip
 
       - name: Download coverage data

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/readfish
     permissions:
-      id-token: write 
+      id-token: write
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,14 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [refactor, main]
+    tags: ["*"]
   schedule:
-    - cron:  '0 0 * * SUN'
+    - cron:  '0 8 * * MON'
   pull_request:
-    branches:
-      - refactor
-      - main
-    types:
-      - closed
+    branches: [refactor, main]
   workflow_dispatch:
 
 env:
@@ -19,17 +17,20 @@ jobs:
   pre_commit:
     name: "🅿️ pre-commit"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 5
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
           python-version: ${{env.PYTHON_LATEST}}
+          cache: pip
       - uses: "pre-commit/action@v3.0.0"
 
   tests:
     name: "Test Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     needs: "pre_commit"
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -38,82 +39,121 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: pip
       - name: "Run tests"
         run: |
           set -xe
           python -VV
           python -m site
           python -m pip install -U pip setuptools wheel
-          python -m pip install -e ".[dev]"
-          python -m pytest -sv --doctest-modules
-
-
-  deploy-docs:
-    runs-on: ubuntu-22.04
-    needs: "pre_commit"
-    permissions:
-      contents: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v3
+          python -m pip install -e ".[tests]"
+          coverage -m pytest
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
         with:
-          python-version: '3.8'
+          name: coverage-data
+          path: .coverage.*
+          if-no-files-found: ignore
 
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: python3 -m pip install .[docs]
-
-      - run: cd docs && make html
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.event.pull_request.merged == true
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html/
-
-  build_and_deploy:
-    name: Upload release to PyPI
+  coverage:
+    name: Combine coverage
     runs-on: ubuntu-latest
     needs: tests
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version-file: ${{ env.PYTHON_LATEST }}
+          cache: pip
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-data
+
+      - name: Combine coverage
+        run: |
+          python -m pip install coverage[toml]
+          python -m coverage combine
+          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+
+  build-package:
+    name: Build python package
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_LATEST }}
+          cache: pip
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+      - name: Upload built package
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-package
+          path: dist/
+          if-no-files-found: error
+
+  build-docs:
+    name: Build HTML docs
+    runs-on: ubuntu-latest
+    needs: "pre_commit"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_LATEST }}
+          cache: pip
+
+      - name: Build docs
+        run: |
+          python -m pip install .[docs]
+          cd docs
+          make html
+      - name: Upload built HTML
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-docs
+          path: _build/html/
+          if-no-files-found: error
+
+
+  deploy:
+    name: Deploy docs and package
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - build-docs
+      - build-package
     environment:
-      name: pypi
+      name: PyPI
       url: https://pypi.org/p/readfish
     permissions:
       id-token: write
+      contents: write
+
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{env.PYTHON_LATEST}}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatchling
-    - name: Build package
-      run: python -m hatchling build
-    - name: Publish package distributions to PyPI
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download HTML docs
+        uses: actions/download-artifact@v3
+        with:
+          name: html-docs
+          path: _build/html
+      - name: Download python package
+        uses: actions/download-artifact@v3
+        with:
+          name: built-package
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Deploy docs to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html/

--- a/.github/workflows/faqtory.yml
+++ b/.github/workflows/faqtory.yml
@@ -4,6 +4,8 @@ on:
     types: [opened]
 jobs:
   add-comment:
+    # https://docs.github.com/en/actions/learn-github-actions/expressions#example-matching-an-array-of-strings
+    if: ${{ !contains(fromJSON('["alexomics", "Adoni5", "mattloose"]'), github.actor) }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ readfish = "readfish._cli_base:main"
 [project.optional-dependencies]
 # Development dependencies
 docs = ["sphinx-copybutton", "furo", "myst-parser", "faqtory"]
-tests = ["pytest"]
+tests = ["pytest", "coverage[toml]"]
 tests-mappy = ["readfish[tests,mappy,guppy]"]
 dev = ["readfish[all,docs,tests]"]
 # Running dependencies, this is a little bit clunky but works for now
@@ -82,3 +82,4 @@ testpaths = [
 markers = [
     "alignment: marks tests which rely on loading or using Mappy or Mappy-rs aligners, used to test with both. (deselect with '-m \"not slow\", select with '-k alignment')",
 ]
+addopts = ["-ra", "--doctest-modules"]


### PR DESCRIPTION
Closes #274 
Closes #280 

Uses github action pypa/gh-action-pypi-publish@release/v1 to publish sdist and bdist wheel like `readfish-2023.1.0-py3-none-any.whl` to PyPI using trusted publishers.

Addresses all tasks in #280 
