### PR TITLE
Fix broken refactor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ See '<command> --help' to read about a specific sub-command.
 TOML File
 ---------
 For information on the TOML files see [TOML.md](docs/toml.md).
-There are several example TOMLS, with comments explaining what each field does, as well as the overall purpose of the [TOML file here](https://github.com//LooseLab/readfish/tree/refactor/docs/_static/example_tomls) .
+There are several example TOMLS, with comments explaining what each field does, as well as the overall purpose of the [TOML file here](https://github.com//LooseLab/readfish/tree/main/docs/_static/example_tomls) .
 
 <details style="margin-top: 10px; margin-bottom: 10px" open><summary id="testing"><h1 style="display: inline">Testing</h1></summary>
 <!-- begin-test -->

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -83,7 +83,7 @@ Readfish uses [calver](https://calver.org/) for versioning. Specifically the for
 
 
 ## Viewing Documentation
-Aside from a traditional [`README.md`](https://github.com/LooseLab/readfish/blob/refactor/README.md), `readfish` uses [`sphinx`](https://www.sphinx-doc.org/en/master/) to create documentation.
+Aside from a traditional [`README.md`](https://github.com/LooseLab/readfish/blob/main/README.md), `readfish` uses [`sphinx`](https://www.sphinx-doc.org/en/master/) to create documentation.
 All documentation is kept in the `readfish/docs` directory.
 
 A live version is available at https://looselab.github.io/readfish/.
@@ -133,7 +133,7 @@ Currently, two types of plugins can be written
  - `Caller` plugins (must inherit `CallerABC`), which wrap a base caller for calling chunks
  - `Aligner` plugins (must inherit `AlignerABC`), which wrap an aligner for making decisions on base called chunks.
 
-These ABCs are defined in [`abc.py`](https://github.com/LooseLab/readfish/blob/refactor/src/readfish/plugins/abc.py).
+These ABCs are defined in [`abc.py`](https://github.com/LooseLab/readfish/blob/main/src/readfish/plugins/abc.py).
 This means that the methods which are used in `targets.py` are present, so plugins can be swapped out at run time, and function as standardised self-contained interfaces to different external tools.
 
 If a plugin module is written and not included in `readfish` package, but another, it is possible to include it by passing the path in the `toml`.

--- a/docs/questions/creating_readfish-environment.question.md
+++ b/docs/questions/creating_readfish-environment.question.md
@@ -32,5 +32,5 @@ dependencies:
   - pip:
     - git+https://github.com/nanoporetech/read_until_api@3.4.1
     - ont-pyguppy-client-lib==X.X.X
-    - git+https://github.com/LooseLab/readfish@refactor
+    - git+https://github.com/LooseLab/readfish@main
 ```

--- a/docs/questions/readfish-branches.question.md
+++ b/docs/questions/readfish-branches.question.md
@@ -4,6 +4,6 @@ alt_titles:
   - "Suitable readfish branch"
 ---
 
-The `refactor` branch is the most up to date branch of readfish, and is the one we recommend using.
+The `main` branch is the most up to date branch of readfish, and is the one we recommend using.
 Watch this space for any updates!
 See elsewhere in this file for installation FAQs. 🕵️‍♂️

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -3,7 +3,7 @@
 Readfish experiments are configured using [TOML] files, which are minimal and easy-to-read markup files.
 Our configuration only uses [tables] and [arrays of tables] populated with [key-value pairs].
 The TOML file contains almost all the information required for running readfish, such as information on barcodes, control/analysis regions, what basecaller or aligner to use.
-There are several example TOMLS, with comments explaining what each field does, as well as the overall purpose of the TOML file here - https://github.com//LooseLab/readfish/tree/refactor/docs/_static/example_tomls.
+There are several example TOMLS, with comments explaining what each field does, as well as the overall purpose of the TOML file here - https://github.com//LooseLab/readfish/tree/main/docs/_static/example_tomls.
 ## Data model
 
 To understand each section of the TOML file it helps to understand the work that readfish does:


### PR DESCRIPTION
Fixes that were pointing towards `readfish@refactor` and changes them to point at `main`