### PR TITLE
Issue289/fix-region-requirement and add Changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,3 +548,11 @@ And for our Awesome Logo please checkout out [@tim_bassford](https://twitter.com
 [bulk - R9]: https://s3.amazonaws.com/nanopore-human-wgs/bulkfile/PLSP57501_20170308_FNFAF14035_MN16458_sequencing_run_NOTT_Hum_wh1rs2_60428.fast5
 [bulk - R10 5khz]: https://s3.amazonaws.com/nanopore-human-wgs/bulkfile/GXB02001_20230509_1250_FAW79338_X3_sequencing_run_NA12878_B1_19382aa5_ef4362cd.fast5
 [ONT]: https://nanoporetech.com
+
+
+# Changelog
+
+## 2023.1.1
+1. Fix Readme Logo link 🥳 
+1. Fix bug where we had accidentally started requiring barcoded TOMLs to specify a region. Thanks to @jamesemery for catching this.
+1. Correctly handle overriding a decision in internal statistics tracking.

--- a/README.md
+++ b/README.md
@@ -549,10 +549,12 @@ And for our Awesome Logo please checkout out [@tim_bassford](https://twitter.com
 [bulk - R10 5khz]: https://s3.amazonaws.com/nanopore-human-wgs/bulkfile/GXB02001_20230509_1250_FAW79338_X3_sequencing_run_NA12878_B1_19382aa5_ef4362cd.fast5
 [ONT]: https://nanoporetech.com
 
-
+<!-- start-changelog -->
 # Changelog
-
+## Unreleased changes
+None currently.
 ## 2023.1.1
-1. Fix Readme Logo link 🥳 
-1. Fix bug where we had accidentally started requiring barcoded TOMLs to specify a region. Thanks to @jamesemery for catching this.
-1. Correctly handle overriding a decision in internal statistics tracking.
+1. Fix Readme Logo link 🥳 (#296)
+1. Fix bug where we had accidentally started requiring barcoded TOMLs to specify a region. Thanks to @jamesemery for catching this. (#299)
+1. Correctly handle overriding a decision in internal statistics tracking. (#299)
+<!-- end-changelog -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+
+```{include} ../README.md
+:start-after: <!-- start-changelog -->
+:end-before: <!-- end-changelog -->
+```

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -69,6 +69,14 @@ conda env create -f docs/development.yml
 Readfish uses [calver](https://calver.org/) for versioning. Specifically the format should be
 `YYYY.MINOR.MICRO.Modifier`, where `MINOR` is the feature addiiton, `MICRO` is any hotfix/bugfix, and `Modifier` is the modifier (e.g. `rc` for release candidate, `dev` for development, empty for stable).
 
+## Changelog
+
+We are generally trying to follow the guidance lain out here. https://keepachangelog.com/en/1.0.0/
+
+Notably we should correctly update the Unreleased section for things added in the PRs that are inbetween releases.
+
+If possible, link the PR that introduced the change, and add a **brief** description of the change.
+
 ## Adding a simulated position for testing
 ```{include} ../README.md
 :start-after: <!-- begin-simulate -->

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -71,7 +71,7 @@ Readfish uses [calver](https://calver.org/) for versioning. Specifically the for
 
 ## Changelog
 
-We are generally trying to follow the guidance lain out here. https://keepachangelog.com/en/1.0.0/
+We are generally trying to follow the guidance here. https://keepachangelog.com/en/1.0.0/
 
 Notably we should correctly update the Unreleased section for things added in the PRs that are inbetween releases.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ FAQ
 post-analysis
 developers-guide
 readfish
+changelog
 ```
 
 # Welcome to the readfish documentation!
@@ -27,10 +28,4 @@ For information on the readfish TOML files see {doc}`toml`
 ```{include} ../README.md
 :start-after: <!-- begin-epilog -->
 :end-before: <!-- end-epilog -->
-```
-
-
-```{include} ../README.md
-:start-after: <!-- start-changelog -->
-:end-before: <!-- end-changelog -->
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,11 @@ For information on the readfish TOML files see {doc}`toml`
 :start-after: <!-- begin-epilog -->
 :end-before: <!-- end-epilog -->
 ```
+
+
+Change Log
+----------
+```{include} ../README.md
+:start-after: <!-- start-changelog -->
+:end-before: <!-- end-changelog -->
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,6 @@ For information on the readfish TOML files see {doc}`toml`
 ```
 
 
-Change Log
-----------
 ```{include} ../README.md
 :start-after: <!-- start-changelog -->
 :end-before: <!-- end-changelog -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -48,7 +49,7 @@ readfish = "readfish._cli_base:main"
 docs = ["sphinx-copybutton", "furo", "myst-parser", "faqtory"]
 tests = ["pytest", "coverage[toml]"]
 tests-mappy = ["readfish[tests,mappy,guppy]"]
-dev = ["readfish[all,docs,tests]"]
+dev = ["readfish[all,docs,tests]", "pre-commit"]
 # Running dependencies, this is a little bit clunky but works for now
 mappy = ["mappy"]
 mappy-rs = ["mappy-rs >= 0.0.6"]
@@ -56,7 +57,7 @@ guppy = ["ont_pyguppy_client_lib"]
 all = ["readfish[mappy,mappy-rs,guppy]"]
 
 [project.urls]
-# Documentation = "https://looselab.github.io/readfish"
+Documentation = "https://looselab.github.io/readfish"
 "Bug Tracker" = "https://github.com/LooseLab/readfish/issues"
 "Source Code" = "https://github.com/LooseLab/readfish"
 

--- a/src/readfish/__about__.py
+++ b/src/readfish/__about__.py
@@ -1,4 +1,4 @@
 """__about__.py
 Version of the read until software
 """
-__version__ = "2023.1.1.dev"
+__version__ = "2023.1.1"

--- a/src/readfish/__about__.py
+++ b/src/readfish/__about__.py
@@ -1,4 +1,4 @@
 """__about__.py
 Version of the read until software
 """
-__version__ = "2023.1.0"
+__version__ = "2023.1.1.dev"

--- a/src/readfish/_statistics.py
+++ b/src/readfish/_statistics.py
@@ -334,12 +334,12 @@ None, None, False, 0.0))), region_name="naff", overridden_action_name=None)
         """
         Add a new read chunk record into the collected statistics,
         and log it to the debug logger.
-    The following terms are used in this function:
-    decision is expected to be one of Unblock, stop_receiving etc.
-    mode is expected to be one of single_on, single_off, multi_on etc.
-    
-    The term "action" is used to describe what the sequener actually did.
-    #ToDo: see and address issue #298
+        The following terms are used in this function:
+        decision is expected to be one of Unblock, stop_receiving etc.
+        mode is expected to be one of single_on, single_off, multi_on etc.
+        
+        The term "action" is used to describe what the sequener actually did.
+        #ToDo: see and address issue #298
         :param region_name: The name of the region on the flow cell.
         :param overridden_action_name: Optional, if the originally determined action
         was overridden, the name of the NEW action.

--- a/src/readfish/_statistics.py
+++ b/src/readfish/_statistics.py
@@ -334,11 +334,12 @@ None, None, False, 0.0))), region_name="naff", overridden_action_name=None)
         """
         Add a new read chunk record into the collected statistics,
         and log it to the debug logger.
+
         The following terms are used in this function:
         decision is expected to be one of Unblock, stop_receiving etc.
         mode is expected to be one of single_on, single_off, multi_on etc.
-        
-        The term "action" is used to describe what the sequener actually did.
+
+        The term "action" is used to describe what the sequencer actually did.
         #ToDo: see and address issue #298
         :param region_name: The name of the region on the flow cell.
         :param overridden_action_name: Optional, if the originally determined action

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -412,13 +412,19 @@ class Analysis:
                     decision=action.name,
                     condition=condition.name,
                     barcode=result.barcode,
-                    previous_action=previous_action.name
-                    if previous_action is not None
-                    else previous_action,
+                    previous_action=(
+                        previous_action.name
+                        if previous_action is not None
+                        else previous_action
+                    ),
                     action_overridden=action_overridden,
                     timestamp=time.time(),
                     # Anything below here is not included in the Debug log
-                    region_name=self.conf.get_region(result.channel).name,
+                    region_name=(
+                        _region.name
+                        if (_region := self.conf.get_region(result.channel))
+                        else "flowcell"
+                    ),
                 )
 
             #######################################################################

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -255,7 +255,7 @@ class Analysis:
         condition: _Condition,
         stop_receiving_action_list: list[tuple[int, int]],
         unblock_batch_action_list: list[tuple[int, int]],
-    ) -> tuple[Action, bool]:
+    ) -> tuple[Action, bool, str | None]:
         """
         Check the chosen Action and amend it based on conditional checks.
         The action lists are appended to in place, so no return is required.
@@ -275,7 +275,8 @@ class Analysis:
         :param stop_receiving_action_list: List to append channels and read numbers for which 'stop receiving' action is decided.
         :param unblock_batch_action_list: List to append channels, read numbers, and read IDs for which 'unblock' action is decided.
 
-        :return: A tuple containing the previous action taken for this read, and a boolean indicating if the action was overridden.
+        :return: A tuple containing the previous action taken for this read,
+          boolean indicating if the action was overridden, and the name of the action overridden too.
 
         """
 
@@ -328,7 +329,11 @@ class Analysis:
                 )
             # Add decided Action
             self.previous_action_tracker.add_action(result.channel, action)
-        return previous_action, action_overridden
+        return (
+            previous_action,
+            action_overridden,
+            action.name if action_overridden else None,
+        )
 
     def run(self):
         """Run the read until loop, in one continuous while loop."""
@@ -391,7 +396,11 @@ class Analysis:
                 action = condition.get_action(result.decision)
                 seen_count = self.chunk_tracker.seen(result.channel, result.read_number)
                 #  Check if there any conditions that override the action chose, exceed_max_chunks etc...
-                previous_action, action_overridden = self.check_override_action(
+                (
+                    previous_action,
+                    action_overridden,
+                    overridden_action_name,
+                ) = self.check_override_action(
                     control,
                     action,
                     result,
@@ -425,6 +434,7 @@ class Analysis:
                         if (_region := self.conf.get_region(result.channel))
                         else "flowcell"
                     ),
+                    overridden_action=overridden_action_name,
                 )
 
             #######################################################################

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -434,7 +434,7 @@ class Analysis:
                         if (_region := self.conf.get_region(result.channel))
                         else "flowcell"
                     ),
-                    overridden_action=overridden_action_name,
+                    overridden_action_name=overridden_action_name,
                 )
 
             #######################################################################


### PR DESCRIPTION
Adds a Changelog to the Readme

Uses @alexomics fix to the Region name being required when tracking the read during stats.

Also addresses a logic issue in the `ReadfishStatistics` class about tracking overridden actions. Now tracks overridden actions correctly, for both Regions and Barcodes in the Counters.

Adds a big old set of doctests for the `_update_condition_counter` function.

Finally, I removed the `.dev` tag from the release, as this is not a `dev`/test feature release, just a bug fix.

When this is merged, we should tag as 2023.1.1, and yank the 2023.1.0 from PyPI.

Tested (Briefly!) with Barcoded, Barcoded with regions, and just region tomls.

