### PR TITLE
Fix changing directory after 60 seconds if no run folder

### DIFF
--- a/src/readfish/_read_until_client.py
+++ b/src/readfish/_read_until_client.py
@@ -77,9 +77,9 @@ class RUClient(ReadUntilClient):
         try:
             ids_log = self.mk_run_dir.joinpath("unblocked_read_ids.txt")
             ids_log.touch(exist_ok=True)
-        except PermissionError:
+        except (PermissionError, FileNotFoundError):
             # TODO: log message here that fallback output is in use
-            self.mk_run_dir = "."
+            self.mk_run_dir = Path(".")
             ids_log = self.mk_run_dir.joinpath("unblocked_read_ids.txt")
             ids_log.touch(exist_ok=True)
         self.unblock_logger = setup_logger(


### PR DESCRIPTION
Excepts the File Not Found Error if the run folder doesn't appear after 60 seconds - and sets the output directory to the current working directory.

