### PR TITLE
Feature/duplex

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
           python -m site
           python -m pip install -U pip setuptools wheel
           python -m pip install -e ".[tests]"
-          coverage run --omit "src/readfish/read_until/*.py" -pm pytest
+          coverage run --omit "src/readfish/read_until/*.py,src/readfish/entry_points/targets.py" -pm pytest
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ And for our Awesome Logo please checkout out [@tim_bassford](https://twitter.com
 # Changelog
 ## Unreleased changes
 1. Change the default `unblock_duration` on the `Analysis` class to use `DEFAULT_UNBLOCK` value defined in `_cli_args.py`. Change type on the Argparser for `--unblock-duration` to float. (#313)
+1. Big dog Duplex feature - adds ability to select duplex reads that cover a target region. See pull request for details [(#324)](https://github.com/LooseLab/readfish/pull/324)
 ## 2023.1.1
 1. Fix Readme Logo link 🥳 (#296)
 1. Fix bug where we had accidentally started requiring barcoded TOMLs to specify a region. Thanks to @jamesemery for catching this. (#299)

--- a/src/readfish/__about__.py
+++ b/src/readfish/__about__.py
@@ -1,4 +1,4 @@
 """__about__.py
 Version of the read until software
 """
-__version__ = "2023.1.1"
+__version__ = "2024.2.0a"

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -5,7 +5,17 @@ The two primary items that are exported are ``BASE_ARGS`` and ``DEVICE_BASE_ARGS
 ``BASE_ARGS`` are the minimal required arguments for _all_ entry points as they used for initialising loggers.
 ``DEVICE_BASE_ARGS`` are the set of arguments that are used for connecting to a sequencer (device) and some other related settings for selective sequencing scripts.
 """
+
+from enum import Enum, unique
 from readfish._utils import nice_join
+
+
+@unique
+class Chemistry(Enum):
+    DUPLEX = "duplex"
+    SIMPLEX = "simplex"
+    DUPLEX_SIMPLE = "duplex_simple"
+
 
 DEFAULT_SERVER_HOST = "127.0.0.1"
 DEFAULT_SERVER_PORT = None
@@ -134,11 +144,14 @@ DEVICE_BASE_ARGS = (
         ),
     ),
     (
-        "--duplex",
+        "--chemistry",
         dict(
-            help="**EXPERIMENTAL** Enable duplex targets mode. Accepts reads that align to the opposite strand and same contig as the previous read on channel.",
+            help="**EXPERIMENTAL** Choose between duplex and simplex chemistry mode. duplex_simple accept a read if the previous channels read was stop receiving,"
+            "duplex checks that the previous reads alignment was on the same contig and opposite strand. default: SIMPLEX",
             required=False,
-            action="store_true",
+            type=str,
+            default=Chemistry.SIMPLEX,
+            choices=[chemistry.name for chemistry in Chemistry],
         ),
     ),
 ) + BASE_ARGS

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -133,4 +133,12 @@ DEVICE_BASE_ARGS = (
             type=int,
         ),
     ),
+    (
+        "--duplex",
+        dict(
+            help="**EXPERIMENTAL** Enable duplex targets mode. Accepts reads that align to the opposite strand and same contig as the previous read on channel.",
+            required=False,
+            action="store_true",
+        ),
+    ),
 ) + BASE_ARGS

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -12,8 +12,11 @@ from readfish._utils import nice_join
 
 @unique
 class Chemistry(Enum):
+    #: For the "smarter" version of duplex - does this read map to the previous reads opposite strand on the same contig. Won't work for no map based decisions
     DUPLEX = "duplex"
+    #: Normal simplex chemistry - no duplex override shenanigans
     SIMPLEX = "simplex"
+    #: Simple duplex - if we are going to unblock a read given the previous read on the same channel was stop receiving, sequence the current read instead.
     DUPLEX_SIMPLE = "duplex_simple"
 
 

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -151,7 +151,7 @@ DEVICE_BASE_ARGS = (
             required=False,
             type=str,
             default=Chemistry.SIMPLEX,
-            choices=[chemistry.name for chemistry in Chemistry],
+            choices=[chemistry.value for chemistry in Chemistry],
         ),
     ),
 ) + BASE_ARGS

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -149,7 +149,7 @@ DEVICE_BASE_ARGS = (
     (
         "--chemistry",
         dict(
-            help="**EXPERIMENTAL** Choose between duplex and simplex chemistry mode. duplex_simple accept a read if the previous channels read was stop receiving,"
+            help="**EXPERIMENTAL** Choose between duplex and simplex chemistry mode. duplex_simple accepts a read if the previous channels read was stop receiving,"
             "duplex checks that the previous reads alignment was on the same contig and opposite strand. default: SIMPLEX",
             required=False,
             type=str,

--- a/src/readfish/_loggers.py
+++ b/src/readfish/_loggers.py
@@ -4,6 +4,7 @@ import argparse
 from logging.handlers import QueueHandler, QueueListener
 import queue
 from typing import Callable
+from readfish.__about__ import __version__
 
 
 def setup_logger(
@@ -109,3 +110,4 @@ def print_args(
     for attr in dir(args):
         if attr[0] != "_" and attr not in exclude and attr.lower() == attr:
             printer(f"{attr}={getattr(args, attr)!r}")
+        printer(f"Version={__version__}")

--- a/src/readfish/_loggers.py
+++ b/src/readfish/_loggers.py
@@ -110,4 +110,4 @@ def print_args(
     for attr in dir(args):
         if attr[0] != "_" and attr not in exclude and attr.lower() == attr:
             printer(f"{attr}={getattr(args, attr)!r}")
-        printer(f"Version={__version__}")
+    printer(f"Version={__version__}")

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -81,7 +81,7 @@ from readfish.read_until import ReadUntilClient
 from minknow_api import protocol_service
 
 # Library
-from readfish._cli_args import DEVICE_BASE_ARGS, DEFAULT_UNBLOCK
+from readfish._cli_args import DEVICE_BASE_ARGS
 from readfish._read_until_client import RUClient
 from readfish._config import Action, Conf, make_decision, _Condition
 from readfish._statistics import ReadfishStatistics
@@ -147,10 +147,10 @@ class Analysis:
         conf: Conf,
         logger: logging.Logger,
         debug_log: bool,
-        throttle: float = 0.1,
-        unblock_duration: float = DEFAULT_UNBLOCK,
-        dry_run: bool = False,
-        toml: str = "a.toml",
+        throttle: float,
+        unblock_duration: float,
+        dry_run: bool,
+        toml: str,
     ):
         self.client = client
         self.conf = conf

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -394,7 +394,7 @@ class Analysis:
                 )
 
         # If we have made a final decision for this read and we shouldn't see it again!
-        if action is Action.unblock or Action is Action.stop_receiving:
+        if action is Action.unblock or action is Action.stop_receiving:
             # Add decided Action
             self.previous_action_tracker.add_action(result.channel, action)
             # Add duplex based tracking if we are in duplex mode

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -346,7 +346,7 @@ class Analysis:
             and self.duplex_tracker.get_previous_decision(result.channel)
             not in DISALLOWED_DUPLEX_DECISIONS
         ):  # TODO R
-            self.logger.info(
+            self.logger.debug(
                 f"Overriding to duplex - previous read action {previous_action}, current_action: {action},"
                 f" previous_decision: {self.duplex_tracker.get_previous_decision(result.channel)}"
             )

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -130,7 +130,7 @@ _cli = DEVICE_BASE_ARGS + (
         ),
     ),
 )
-# Whe sequencing in duplex mode, overriding a decided `Action` on a currently sequenced molecule
+# When sequencing in duplex mode, overriding a decided `Action` on a currently sequenced molecule
 # is not allowed if the previous molecules decision was one of these.
 DISALLOWED_DUPLEX_DECISIONS = {Decision.first_read_override, Decision.duplex_override}
 

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -167,7 +167,7 @@ class Analysis:
         self.dry_run = dry_run
         self.live_toml = Path(f"{toml}_live").resolve()
         self.run_information = self.client.connection.protocol.get_run_info()
-
+        self.chemistry = chemistry
         # Generate a run specific read log
         read_log_name = (
             f"{self.run_information.run_id}_readfish.tsv" if debug_log else None

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -332,7 +332,7 @@ class Analysis:
         ):
             # Check if we think this read is possibly duplex
             possible_duplex = any(
-                self.previous_alignment_tracker.possible_duplex(
+                self.duplex_tracker.possible_duplex(
                     result.channel, result.read_id, al.ctg, Strand(al.strand)
                 )
                 for al in result.alignment_data

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -360,7 +360,7 @@ class Analysis:
             # Add decided Action
             self.previous_action_tracker.add_action(result.channel, action)
             # Add final decision - used to check if it is a duplex override
-            self.duplex_tracker.set_previous_decision(result.decision)
+            self.duplex_tracker.set_previous_decision(result.channel, result.decision)
         elif action is Action.unblock:
             if self.dry_run:
                 # Log an 'unblock' action to previous action, but send a 'stop receiving' to prevent further read processing.
@@ -372,7 +372,7 @@ class Analysis:
                 )
             # Add decided Action
             self.previous_action_tracker.add_action(result.channel, action)
-            self.duplex_tracker.set_previous_decision(result.decision)
+            self.duplex_tracker.set_previous_decision(result.channel, result.decision)
 
         return (
             previous_action,

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -481,9 +481,9 @@ class Analysis:
                     ),
                     overridden_action_name=overridden_action_name,
                 )
-                self.previous_alignment_tracker.add_alignment(
-                    result.channel,
-                )
+                # self.duplex_tracker.add_alignments(
+                #     result.channel,
+                # )
 
             #######################################################################
             # Compile actions to be sent

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -327,7 +327,8 @@ class Analysis:
             and previous_action == Action.stop_receiving
             # And we aren't already sequencing it
             and action != Action.stop_receiving
-            and self.duplex_tracker.get_previous_decision() != Decision.duplex_override
+            and self.duplex_tracker.get_previous_decision(result.channel)
+            != Decision.duplex_override
         ):
             self.logger.debug(
                 f"Overriding read {result.read_id} as it is possibly second half of a duplex"
@@ -340,7 +341,8 @@ class Analysis:
             self.chemistry == Chemistry.DUPLEX_SIMPLE
             and previous_action == Action.stop_receiving
             and action != Action.stop_receiving
-            and self.duplex_tracker.get_previous_decision() != Decision.duplex_override
+            and self.duplex_tracker.get_previous_decision(result.channel)
+            != Decision.duplex_override
         ):
             action = Action.stop_receiving
             action_overridden = True
@@ -481,9 +483,10 @@ class Analysis:
                     ),
                     overridden_action_name=overridden_action_name,
                 )
-                # self.duplex_tracker.add_alignments(
-                #     result.channel,
-                # )
+            # if self.chemistry == Chemistry.DUPLEX:
+            #     self.duplex_tracker.add_alignments(
+            #         result.channel, [()]
+            #     )
 
             #######################################################################
             # Compile actions to be sent

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -128,6 +128,7 @@ _cli = DEVICE_BASE_ARGS + (
         ),
     ),
 )
+DISALLOWED_DUPLEX_DECISIONS = {Decision.first_read_override, Decision.duplex_override}
 
 
 class Analysis:
@@ -315,6 +316,7 @@ class Analysis:
         previous_action = self.previous_action_tracker.get_action(result.channel)
         action_overridden = False
         # If --duplex flag override decisions made based on the strand and contig alignment of the previous read.
+        # Unfinished bruv
         if (
             self.chemistry == Chemistry.DUPLEX
             and any(
@@ -340,10 +342,10 @@ class Analysis:
         elif (
             self.chemistry == Chemistry.DUPLEX_SIMPLE
             and previous_action == Action.stop_receiving
-            and action != Action.stop_receiving
+            and action == Action.unblock
             and self.duplex_tracker.get_previous_decision(result.channel)
-            != Decision.duplex_override
-        ):  # TODO REMOVE
+            not in DISALLOWED_DUPLEX_DECISIONS
+        ):  # TODO R
             self.logger.info(
                 f"Overriding to duplex - previous read action {previous_action}, current_action: {action},"
                 f" previous_decision: {self.duplex_tracker.get_previous_decision(result.channel)}"

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -11,6 +11,10 @@ Then, during sequencing the start of each read is sampled.
 These chunks of raw data are processed by the basecaller to produce FASTA, which is then aligned against the chosen reference genome.
 The result of the alignment is used, along with the targets provided in the :doc:`TOML <toml>` file, to make a decision on each read.
 
+In the new **experimental** Duplex mode, it is possible to override a decision for a read based on the action taken for a previous read.
+This is done by passing `--chemistry` and setting either duplex, or duplex simple.
+`duplex_simple` accepts a read if the previous channels read was stop receiving, `duplex` checks that the previous reads alignment was on the same contig and opposite strand.
+The default chemistry is simplex.
 
 Running this should result in a very short (<1kb, ideally 400-600 bases) unblock peak at the start of a read length histogram and longer sequenced reads.
 
@@ -21,6 +25,15 @@ Example run command::
            --toml my_exp.toml \\
            --log-file rf.log \\
            --debug-log chunks.tsv
+
+Example experimental duplex command::
+
+    readfish targets --device X3 \\
+           --experiment-name "test" \\
+           --toml my_exp.toml \\
+           --log-file rf.log \\
+           --debug-log chunks.tsv
+           --chemistry duplex
 
 In the debug_log chunks.tsv file, if this argument is passed, each line represents detailed information about a batch of
 read signal that has been processed in an iteration.

--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -343,7 +343,11 @@ class Analysis:
             and action != Action.stop_receiving
             and self.duplex_tracker.get_previous_decision(result.channel)
             != Decision.duplex_override
-        ):
+        ):  # TODO REMOVE
+            self.logger.info(
+                f"Overriding to duplex - previous read action {previous_action}, current_action: {action},"
+                f" previous_decision: {self.duplex_tracker.get_previous_decision(result.channel)}"
+            )
             action = Action.stop_receiving
             action_overridden = True
             result.decision = Decision.duplex_override

--- a/src/readfish/plugins/utils.py
+++ b/src/readfish/plugins/utils.py
@@ -912,5 +912,5 @@ class DuplexTracker:
         strand = Strand(strand)
         return any(
             prev_alignment == (target_name, ~strand)
-            for prev_alignment in self.get_previous_alignment(channel)
+            for prev_alignment in self.get_previous_alignments(channel)
         )

--- a/src/readfish/plugins/utils.py
+++ b/src/readfish/plugins/utils.py
@@ -30,6 +30,16 @@ class Strand(Enum):
     #: Reverse strand
     reverse = "-"
 
+    def __invert__(self):
+        """Flip the strand, using bitwise NOT (~)
+
+        >>> ~Strand.forward
+        <Strand.reverse: '-'>
+        >>> ~Strand.reverse
+        <Strand.forward: '+'>
+        """
+        return Strand.forward if self is Strand.reverse else Strand.reverse
+
 
 STRANDS = {
     1: Strand.forward,

--- a/src/readfish/plugins/utils.py
+++ b/src/readfish/plugins/utils.py
@@ -820,6 +820,9 @@ class DuplexTracker:
     No maps are specified as (*, *)
     """
 
+    # Note - `readfish.src.plugins.utils.Alignment` could be used here, instead of tuple[str, Strand]
+    # We could then use the results of the ALignment directly, if we ever wanted to do something more complex
+    # for duplex
     previous_alignments: Dict[int, list[tuple[str, Strand]]] = attrs.Factory(dict)
     previous_decision: Dict[int, Decision] = attrs.Factory(dict)
 

--- a/src/readfish/plugins/utils.py
+++ b/src/readfish/plugins/utils.py
@@ -170,11 +170,16 @@ def count_dict_elements(d: dict[Any]) -> int:
     """
     return sum(
         (
-            count_dict_elements(v) if isinstance(v, dict)
-            # If v is a list, tuple, sequence, dict etc., return the length of the container filtering out any empty sun elements,
-            else len(list(filterfalse(partial(is_empty), v)))
-            if isinstance(v, Container)
-            else 1
+            (
+                count_dict_elements(v)
+                if isinstance(v, dict)
+                # If v is a list, tuple, sequence, dict etc., return the length of the container filtering out any empty sun elements,
+                else (
+                    len(list(filterfalse(partial(is_empty), v)))
+                    if isinstance(v, Container)
+                    else 1
+                )
+            )
             for v in d.values()
         )
     )

--- a/src/readfish/plugins/utils.py
+++ b/src/readfish/plugins/utils.py
@@ -820,8 +820,14 @@ class DuplexTracker:
 
         :param channel: The channel number.
         :return: Previously seen decision
+        >>> dt = DuplexTracker()
+        >>> dt.get_previous_decision(1) is None
+        True
+        >>> dt.set_previous_decision(1, Decision.duplex_override)
+        >>> dt.get_previous_decision(1)
+        <Decision.duplex_override: 'duplex_override'>
         """
-        self.previous_decision.get(channel, None)
+        return self.previous_decision.get(channel, None)
 
     def set_previous_decision(self, channel: int, decision: Decision) -> None:
         """
@@ -830,6 +836,10 @@ class DuplexTracker:
         :param channel: The channel number.
         :param decision: The decision taken. Should be the final decision,
         i.e we won't see the read again.
+        >>> dt = DuplexTracker()
+        >>> dt.set_previous_decision(1, Decision.no_map)
+        >>> dt.previous_decision[1]
+        <Decision.no_map: 'no_map'>
         """
         self.previous_decision[channel] = decision
 
@@ -840,6 +850,13 @@ class DuplexTracker:
         :param channel: The channel number to lookup the previous action for
         :param read_id: Read of ID of the current alignment
         :return: Returns a tuple of (contig_name, strand), for the last alignment seen on this channel
+
+        >>> dt = DuplexTracker()
+        >>> dt.get_previous_alignment(1) is None
+        True
+        >>> dt.add_alignments(1, [("contig1", Strand.forward), ("contig2", Strand.reverse)])
+        >>> dt.get_previous_alignment(1)
+        [('contig1', <Strand.forward: '+'>), ('contig2', <Strand.reverse: '-'>)]
         """
         return self.previous_alignments.get(channel, None)
 
@@ -852,6 +869,11 @@ class DuplexTracker:
         :param channel: The channel number to set the alignment for.
         :param target_name: The name of the target contig aligned to
         :param strand: The strand we have aligned to.
+
+        >>> dt = DuplexTracker()
+        >>> dt.add_alignments(1, [("contig3", Strand.forward), ("contig4", Strand.reverse)])
+        >>> dt.previous_alignments[1]
+        [('contig3', <Strand.forward: '+'>), ('contig4', <Strand.reverse: '-'>)]
         """
         self.previous_alignments[channel] = alignments
 
@@ -865,6 +887,13 @@ class DuplexTracker:
         :param target_name: The name of the target contig for the current alignment
         :param strand: The strand of the current alignment
         :return: True if the strand is opposite and target contig the same
+
+        >>> dt = DuplexTracker()
+        >>> dt.add_alignments(1, [("contig5", Strand.forward)])
+        >>> dt.possible_duplex(1, "contig5", Strand.reverse)
+        True
+        >>> dt.possible_duplex(1, "contig6", Strand.reverse)
+        False
         """
         return any(
             prev_alignment

--- a/tests/static/mappy_validation_test/fail/001_wrong_reference_type.txt
+++ b/tests/static/mappy_validation_test/fail/001_wrong_reference_type.txt
@@ -1,1 +1,1 @@
-Provided index file (.txt) appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
+Provided index file appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']

--- a/tests/static/mappy_validation_test/fail/001_wrong_reference_type.txt
+++ b/tests/static/mappy_validation_test/fail/001_wrong_reference_type.txt
@@ -1,1 +1,1 @@
-Provided index file appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
+Provided index file (.txt) appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']

--- a/tests/static/mappy_validation_test/fail/003_wrong_reference_type_mmi_gz.txt
+++ b/tests/static/mappy_validation_test/fail/003_wrong_reference_type_mmi_gz.txt
@@ -1,1 +1,1 @@
-Provided index file appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
+Provided index file (.mmi.gz) appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']

--- a/tests/static/mappy_validation_test/fail/003_wrong_reference_type_mmi_gz.txt
+++ b/tests/static/mappy_validation_test/fail/003_wrong_reference_type_mmi_gz.txt
@@ -1,1 +1,1 @@
-Provided index file (.mmi.gz) appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
+Provided index file appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']


### PR DESCRIPTION
### Two implementations of _simple_ duplex targeting

* Initial implementation of the "chill" accept if the previous read was deliberately sequenced, and this one otherwise wouldn't be, which has been included to account for sequencing duplex with `no_map` as the decision.

* The slightly more complex previous alignment was sequenced, and this read aligns to the opposite strand on the same contig.

Both of these modes break the chain of `stop_receiving` if the previous read was only sequenced if it was potentially duplex, by checking the new `duplex_override` decision, on the `duplex_tracker`.

Other things of note:
1. Version is included in the printed output at the top of the logs
1. Small change to an error in mappy.py index extension checking, which not includes the extension that is incorrect for clearer error messaging
1. Added a new decision of when we override a read at the start of a readfish run, if the translocated portion is of unknown length