### PR TITLE
Change type on --wait-for-ready to int

### DIFF
--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -127,9 +127,10 @@ DEVICE_BASE_ARGS = (
     (
         "--wait-for-ready",
         dict(
-            help="Timeout for the MinKNOW data folder to appear, and the device to report it is ready to start sequencing. Default 60 seconds.",
+            help="Timeout for the MinKNOW data folder to appear, and the device to report it is ready to start sequencing in seconds. (default: 60s).",
             required=False,
             default=60,
+            type=int,
         ),
     ),
 ) + BASE_ARGS

--- a/src/readfish/_cli_args.py
+++ b/src/readfish/_cli_args.py
@@ -127,9 +127,9 @@ DEVICE_BASE_ARGS = (
     (
         "--wait-for-ready",
         dict(
-            help="Timeout for the MinKNOW data folder to appear, and the device to report it is ready to start sequencing in seconds. (default: 60s).",
+            help="Timeout for the MinKNOW data folder to appear, and the device to report it is ready to start sequencing in seconds. (default: 120s).",
             required=False,
-            default=60,
+            default=120,
             type=int,
         ),
     ),

--- a/src/readfish/_read_until_client.py
+++ b/src/readfish/_read_until_client.py
@@ -41,6 +41,8 @@ class RUClient(ReadUntilClient):
     """Subclasses ONTs read_until_api ReadUntilClient adding extra function that logs unblocks read_ids."""
 
     def __init__(self, *args, **kwargs):
+        #  Default to TIMEOUT in the event we are not starting from the CLI.
+        # If started from CLI args.wait-for-ready is used - also defaults to 120s
         self.timeout = kwargs.pop("timeout", TIMEOUT)
         super().__init__(*args, **kwargs)
         # disable the read until client logger
@@ -170,10 +172,10 @@ class RUClient(ReadUntilClient):
             else:
                 raise SystemExit(1)
 
-    def wait_for_minknow_folder(self, timeout: int = TIMEOUT):
+    def wait_for_minknow_folder(self, timeout: int):
         """
         Rather than messing about with permissions wait for MinKNOW to create the run
-        folder. If the folder doesn't appear after TIMEOUT seconds then write to the
+        folder. If the folder doesn't appear after timeout seconds then write to the
         current working directory instead.
         """
         seconds_waited = 0


### PR DESCRIPTION
Adds type to `wait-for-ready` argument - clearly I hadn't tested it because recently because I get!

```bash
Traceback (most recent call last):
  File "/home/adoni5/miniforge3/envs/readfish/bin/readfish", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/adoni5/Projects/readfish/src/readfish/_cli_base.py", line 61, in main
    raise SystemExit(args.func(parser, args, extras))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/adoni5/Projects/readfish/src/readfish/entry_points/targets.py", line 549, in run
    read_until_client = RUClient(
                        ^^^^^^^^^
  File "/home/adoni5/Projects/readfish/src/readfish/_read_until_client.py", line 73, in __init__
    self.wait_for_minknow_folder(self.timeout)
  File "/home/adoni5/Projects/readfish/src/readfish/_read_until_client.py", line 186, in wait_for_minknow_folder
    if seconds_waited > timeout:
       ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'int' and 'str'
```

This PR fixes that