### PR TITLE
Adding additional .mmi extensions to all possible fasta file format l…

### DIFF
--- a/src/readfish/plugins/_mappy.py
+++ b/src/readfish/plugins/_mappy.py
@@ -82,18 +82,12 @@ class _Aligner(AlignerABC):
         :return: None, if the Aligner is setup with valid paths and permissions
         """
         index: str = self.aligner_params["fn_idx_in"]
-        file_extensions = []
-        file_extension = [".fasta", ".fna", ".fsa", ".fa", ".fastq", ".fq"]
-        file_extensions.extend([f"{f}.gz" for f in file_extension])
-        file_extensions.extend([f"{f}.mmi" for f in file_extension])
-        file_extensions.extend(file_extension)
-        file_extensions.append(".mmi")
+        file_extensions = ['.fasta', '.fna', '.fsa', '.fa', '.fastq',
+                           '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz',
+                           '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
         if all((not Path(index).is_file(), index)):
             raise FileNotFoundError(f"{index} does not exist")
-        if (
-            "".join(map(str.lower, Path(index).suffixes)) not in set(file_extensions)
-            and index
-        ):
+        if not any(index.lower().endswith(suffix) for suffix in file_extensions):
             raise RuntimeError(
                 f"Provided index file appears to be of an incorrect type - should be one of {file_extensions}"
             )

--- a/src/readfish/plugins/_mappy.py
+++ b/src/readfish/plugins/_mappy.py
@@ -83,21 +83,9 @@ class _Aligner(AlignerABC):
         :return: None, if the Aligner is setup with valid paths and permissions
         """
         index: str = self.aligner_params["fn_idx_in"]
-        file_extensions = [
-            ".fasta",
-            ".fna",
-            ".fsa",
-            ".fa",
-            ".fastq",
-            ".fq",
-            ".fasta.gz",
-            ".fna.gz",
-            ".fsa.gz",
-            ".fa.gz",
-            ".fastq.gz",
-            ".fq.gz",
-            ".mmi",
-        ]
+        file_extensions = [".fasta", ".fna", ".fsa", ".fa", ".fastq", ".fq"]
+        file_extensions.extend([f"{f}.gz" for f in file_extensions])
+        file_extensions.append(".mmi")
         if all((not Path(index).is_file(), index)):
             raise FileNotFoundError(f"{index} does not exist")
         if not any(index.lower().endswith(suffix) for suffix in file_extensions):

--- a/src/readfish/plugins/_mappy.py
+++ b/src/readfish/plugins/_mappy.py
@@ -82,8 +82,11 @@ class _Aligner(AlignerABC):
         :return: None, if the Aligner is setup with valid paths and permissions
         """
         index: str = self.aligner_params["fn_idx_in"]
-        file_extensions = [".fasta", ".fna", ".fsa", ".fa", ".fastq", ".fq"]
-        file_extensions.extend([f"{f}.gz" for f in file_extensions])
+        file_extensions = []
+        file_extension = [".fasta", ".fna", ".fsa", ".fa", ".fastq", ".fq"]
+        file_extensions.extend([f"{f}.gz" for f in file_extension])
+        file_extensions.extend([f"{f}.mmi" for f in file_extension])
+        file_extensions.extend(file_extension)
         file_extensions.append(".mmi")
         if all((not Path(index).is_file(), index)):
             raise FileNotFoundError(f"{index} does not exist")

--- a/src/readfish/plugins/_mappy.py
+++ b/src/readfish/plugins/_mappy.py
@@ -1,6 +1,7 @@
 """Mapping interface for readfish, using Minimap2 mappy, or mappy-rs as dictated by the experiment TOML
 `mapper_settings.<PLUGIN>` section. See {ref}`plugin configuration <plugins-config>` section.
 """
+
 from __future__ import annotations
 from enum import Enum
 from itertools import chain, repeat
@@ -82,9 +83,21 @@ class _Aligner(AlignerABC):
         :return: None, if the Aligner is setup with valid paths and permissions
         """
         index: str = self.aligner_params["fn_idx_in"]
-        file_extensions = ['.fasta', '.fna', '.fsa', '.fa', '.fastq',
-                           '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz',
-                           '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']
+        file_extensions = [
+            ".fasta",
+            ".fna",
+            ".fsa",
+            ".fa",
+            ".fastq",
+            ".fq",
+            ".fasta.gz",
+            ".fna.gz",
+            ".fsa.gz",
+            ".fa.gz",
+            ".fastq.gz",
+            ".fq.gz",
+            ".mmi",
+        ]
         if all((not Path(index).is_file(), index)):
             raise FileNotFoundError(f"{index} does not exist")
         if not any(index.lower().endswith(suffix) for suffix in file_extensions):

--- a/tests/static/mappy_validation_test/fail/004_bad_reference_file_extension.toml
+++ b/tests/static/mappy_validation_test/fail/004_bad_reference_file_extension.toml
@@ -1,0 +1,13 @@
+[caller_settings.no_op]
+
+[mapper_settings.mappy]
+fn_idx_in = "tests/static/mappy_validation_test/fail/bad_extension.mmi.cabbage"
+
+[[regions]]
+name = "abc"
+no_seq = "proceed"
+no_map = "proceed"
+single_on = "proceed"
+single_off = "proceed"
+multi_on = "proceed"
+multi_off = "proceed"

--- a/tests/static/mappy_validation_test/fail/004_bad_reference_file_extension.txt
+++ b/tests/static/mappy_validation_test/fail/004_bad_reference_file_extension.txt
@@ -1,0 +1,1 @@
+Provided index file appears to be of an incorrect type - should be one of ['.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.mmi']

--- a/tests/static/mappy_validation_test/pass/006_passing_fna_mmi.toml
+++ b/tests/static/mappy_validation_test/pass/006_passing_fna_mmi.toml
@@ -1,7 +1,7 @@
 [caller_settings.no_op]
 
 [mapper_settings.mappy]
-fn_idx_in = "test.mmi.cabbage"
+fn_idx_in = "tests/static/mappy_validation_test/pass/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.mmi"
 
 [[regions]]
 name = "abc"

--- a/tests/static/mappy_validation_test/pass/006_passing_fna_mmi.txt
+++ b/tests/static/mappy_validation_test/pass/006_passing_fna_mmi.txt
@@ -1,0 +1,1 @@
+Aligner initialised

--- a/tests/static/toml_validation_test/fail/005_bad_reference_file.toml
+++ b/tests/static/toml_validation_test/fail/005_bad_reference_file.toml
@@ -1,0 +1,13 @@
+[caller_settings.no_op]
+
+[mapper_settings.mappy]
+fn_idx_in = "test.mmi.cabbage"
+
+[[regions]]
+name = "abc"
+no_seq = "proceed"
+no_map = "proceed"
+single_on = "proceed"
+single_off = "proceed"
+multi_on = "proceed"
+multi_off = "proceed"


### PR DESCRIPTION
…abels to catch acceptable file types.

This request addresses #326 and enables validation of the following file type endings.

['.fasta.gz', '.fna.gz', '.fsa.gz', '.fa.gz', '.fastq.gz', '.fq.gz', '.fasta.mmi', '.fna.mmi', '.fsa.mmi', '.fa.mmi', '.fastq.mmi', '.fq.mmi', '.fasta', '.fna', '.fsa', '.fa', '.fastq', '.fq', '.mmi']

I think a better way to handle this in the future would be to explicitly detemine if the file is readable by mappy. However, this will catch the most common possible mmi extension types.