### PR TITLE
Change Duplex version to 2024.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,8 +553,10 @@ And for our Awesome Logo please checkout out [@tim_bassford](https://twitter.com
 
 <!-- start-changelog -->
 # Changelog
-## Unreleased changes
-1. Change the default `unblock_duration` on the `Analysis` class to use `DEFAULT_UNBLOCK` value defined in `_cli_args.py`. Change type on the Argparser for `--unblock-duration` to float. (#313)
+## 2024.1.0
+1. bug fix type for `--wait-on-ready` type and actual function [(#327)](https://github.com/LooseLab/readfish/pull/327), [(#323)](https://github.com/LooseLab/readfish/pull/323)
+1. mutiple suffix `.mmi` support [(#330)](https://github.com/LooseLab/readfish/pull/330)
+1. Change the default `unblock_duration` on the `Analysis` class to use `DEFAULT_UNBLOCK` value defined in `_cli_args.py`. Change type on the Argparser for `--unblock-duration` to float. [(#313)](https://github.com/LooseLab/readfish/pull/313)
 1. Big dog Duplex feature - adds ability to select duplex reads that cover a target region. See pull request for details [(#324)](https://github.com/LooseLab/readfish/pull/324)
 ## 2023.1.1
 1. Fix Readme Logo link 🥳 (#296)

--- a/src/readfish/__about__.py
+++ b/src/readfish/__about__.py
@@ -1,4 +1,4 @@
 """__about__.py
 Version of the read until software
 """
-__version__ = "2024.2.0a"
+__version__ = "2024.1.0"


### PR DESCRIPTION
Versioning is hard, I guess 2024.2.0a made sense to me at the time?
With this version change the release for duplex is 2024.1.0, which makes a lot more sense

Also updates the changelog to include the correct changes
