### PR TITLE
Dorado Alignments

### DIFF
--- a/docs/toml.md
+++ b/docs/toml.md
@@ -116,6 +116,40 @@ This is added using:
 
 ### Aligner
 
+#### Built-in dorado/guppy alignment
+
+It is possible to leverage the built in dorado/guppy alignment capabilities for readfish.
+This does limit some flexibility in readfish, such as updating the reference.
+
+In order to do this, specify two extra keys in caller settings: `align_ref` and `server_file_load_timeout`.
+
+`align_ref` should be the absolute path to the reference file for alignment. This can be either an `.mmi` or a `FASTA` file.
+
+`server_file_load_timeout` is the number of seconds to wait before the server throws a timeout error whilst loading the reference. The time required scales with the size of the reference, so a large value would make sense, such as 120.
+
+An example TOML for using built in alignment would be:
+```toml
+[caller_settings.dorado]
+               # ^^^^^^
+               # Chooses the dorado plugin
+config = "dna_r10.4.1_e8.2_400bps_5khz_fast_prom"
+address = "ipc:///tmp/.guppy/5555"
+debug_log = "live_reads.fq"
+align_ref = "/data/refs/hg38.p14.simple.mmi"
+server_file_load_timeout = 180
+```
+
+The aligner section of the TOML is required, and so this should be set to, which means the basecaller alignments are used.
+```toml
+[mapper_settings.no_op]
+               # ^^^^^^
+               # Chooses the mappy plugin
+```
+
+**One note** is that there is currently no easy way to change the number of basecaller alignment threads using readfish, and so when the basecaller server instance is started, the number of alignment_threads should be set to a sensible number using the `--num_alignment_threads`
+
+
+
 #### minimap2
 
 Currently we provide two mapping plugins, [`mappy`], and [`mappy-rs`].

--- a/src/readfish/_utils.py
+++ b/src/readfish/_utils.py
@@ -1,12 +1,13 @@
 """utils.py
 functions and utilities used internally.
 """
+
 from __future__ import annotations
 import sys
 import logging
 from collections import Counter
 from functools import reduce
-from operator import itemgetter
+from operator import itemgetter, getitem
 from enum import IntEnum
 import re
 import base64
@@ -78,6 +79,53 @@ def format_bases(num: int, factor: int = 1000, suffix: str = "B") -> str:
             return f"{num:3.2f} {unit}{suffix}"
         num /= factor
     return f"{num:3.2f} Y{suffix}"
+
+
+def get_item(obj: Sequence | Mapping, key: str | int, default: str = "*") -> Any:
+    """
+    Retrieve an item from a sequence or mapping, returning a default value if the item is not found.
+
+    Args:
+        :param obj: The sequence or mapping from which to retrieve the item.
+        :param key: The index or key of the item to retrieve.
+        :param default: The value to return if the item is not found. Defaults to "*".
+
+    Returns:
+        Any: The item from the sequence or mapping, or the default value if the item is not found.
+
+    Examples:
+        >>> get_item([1, 2, 3], 1)
+        2
+        >>> get_item([1, 2, 3], 5)
+        '*'
+        >>> get_item({'a': 1, 'b': 2}, 'b')
+        2
+        >>> get_item({'a': 1, 'b': 2}, 'c')
+        '*'
+        >>> get_item((1, 2, 3), 0)
+        1
+        >>> get_item((1, 2, 3), -1)
+        3
+        >>> get_item((1, 2, 3), 5)
+        '*'
+        >>> get_item((1, 2, 3), 'invalid')
+        '*'
+        >>> get_item(np.array([1, 2, 3]), 1)
+        2
+        >>> get_item(np.array([1, 2, 3]), 5)
+        '*'
+        >>> structured_array = np.array([(1, 'Alice'), (2, 'Bob')], dtype=[('id', 'i4'), ('name', 'U10')])
+        >>> get_item(structured_array, 1)
+        (2, 'Bob')
+        >>> get_item(structured_array, 'name')
+        array(['Alice', 'Bob'], dtype='<U10')
+        >>> get_item(structured_array, 'invalid')
+        '*'
+    """
+    try:
+        return getitem(obj, key)
+    except (IndexError, KeyError, TypeError, ValueError):
+        return default
 
 
 def nested_get(obj: Mapping, key: Any, default: Any = None, *, delim: str = ".") -> Any:

--- a/src/readfish/plugins/_mappy.py
+++ b/src/readfish/plugins/_mappy.py
@@ -23,6 +23,36 @@ from readfish._utils import nice_join
 
 UNMAPPED_PAF = "0\t0\t*\t*\t0\t0\t0\t0\t0\t0"
 
+FIELDS = [
+    "query_name",
+    "query_length",
+    "query_start",
+    "query_end",
+    "strand",
+    "ctg",
+    "target_length",
+    "r_st",
+    "r_en",
+    "residue_matches",
+    "alignment_block_length",
+    "mapping_quality",
+    "tags",
+]
+
+
+class _PAF:
+    """Base PAF methods, can't guarantee field names here so use indices"""
+
+    def __str__(self):
+        """Formats a record as a PAF line for writing to a file"""
+        return "{}\t{}".format("\t".join(map(str, self[:-1])), self._fmt_tags())
+
+    def blast_identity(self):
+        """BLAST identity, see:
+        https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity
+        """
+        return self[9] / self[10]
+
 
 class Aligners(Enum):
     C_MAPPY = "mappy"


### PR DESCRIPTION
Add some extension to the dorado plugin, causing it to set the alignments returned from dorado onto the basecalling result.

Not bothering with Guppy, as it's old.

Also sets reconnect_timeout and server_file_load_timeout to 10 on the `PyBasecallClient` by default meaning we timeout after 10 seconds rather than waiting for 5 minutes 5 times.

Add some code to the `_mappy` to create a PAF record from a list of fields, which is useful for converting the alignment data off the basecall record to a PAF.

Adds some documentation about using it to TOML.md.

Added the `get_item` function to deal with structured numpy arrays, which `nested_get` couldn't do ( I think ).

### Notable

This method means it is **absolutely possible** to use both dorado to align **as well as** mappy, if mapper_settings isn't set to `no_op`.
Any thoughts?
