### PR TITLE
Use `.get` instead of `[]` for strand classifcations

### DIFF
--- a/src/readfish/read_until/base.py
+++ b/src/readfish/read_until/base.py
@@ -201,9 +201,12 @@ class ReadUntilClient(object):
             self.CacheType.__name__,
             filter_to,
         )
-
+        # When there is no run on, MinKNOW only returns a subset of read classifications, and our prefilter classes are not amongst them.
+        # This would then throw an uniformative KeyError. We now just carry on, and get to the point where we try to query about the run 
+        # Which raises a more informative gRPC error instead.
+        # TODO - log the missing strands
         self.strand_classes = set(
-            self.lookup_read_class[x] for x in self.prefilter_classes
+            self.lookup_read_class.get(x, "UhOhNoClassificationioh") for x in self.prefilter_classes
         )
 
         self.logger.debug("Strand-like classes are %s.", self.strand_classes)

--- a/src/readfish/read_until/base.py
+++ b/src/readfish/read_until/base.py
@@ -206,7 +206,7 @@ class ReadUntilClient(object):
         # Which raises a more informative gRPC error instead.
         # TODO - log the missing strands
         self.strand_classes = set(
-            self.lookup_read_class.get(x, "UhOhNoClassificationioh")
+            self.lookup_read_class.get(x, f"{x}_classification_unavailable")
             for x in self.prefilter_classes
         )
 

--- a/src/readfish/read_until/base.py
+++ b/src/readfish/read_until/base.py
@@ -202,7 +202,7 @@ class ReadUntilClient(object):
             filter_to,
         )
         # When there is no run on, MinKNOW only returns a subset of read classifications, and our prefilter classes are not amongst them.
-        # This would then throw an uniformative KeyError. We now just carry on, and get to the point where we try to query about the run 
+        # This would then throw an uniformative KeyError. We now just carry on, and get to the point where we try to query about the run
         # Which raises a more informative gRPC error instead.
         # TODO - log the missing strands
         self.strand_classes = set(

--- a/src/readfish/read_until/base.py
+++ b/src/readfish/read_until/base.py
@@ -206,7 +206,8 @@ class ReadUntilClient(object):
         # Which raises a more informative gRPC error instead.
         # TODO - log the missing strands
         self.strand_classes = set(
-            self.lookup_read_class.get(x, "UhOhNoClassificationioh") for x in self.prefilter_classes
+            self.lookup_read_class.get(x, "UhOhNoClassificationioh")
+            for x in self.prefilter_classes
         )
 
         self.logger.debug("Strand-like classes are %s.", self.strand_classes)


### PR DESCRIPTION
This gets around an uniformative KeyError raised when the run is not on. The missing Keys are not logged (and should be), I have created a separate issue (#390). 

This will make the error that was raised in #389 far more explicit.

In the case that there is no run running, the output now is:
```console
readfish unblock-all --device MS00000 --experiment-name deez
2025-01-28 09:51:02,872 readfish /Users/rory.munro/miniforge3/envs/py310/bin/readfish unblock-all --device MS00000 --experiment-name deez
2025-01-28 09:51:02,872 readfish chemistry=<Chemistry.SIMPLEX: 'simplex'>
2025-01-28 09:51:02,872 readfish command='unblock-all'
2025-01-28 09:51:02,872 readfish debug_log=True
2025-01-28 09:51:02,872 readfish device='MS00000'
2025-01-28 09:51:02,872 readfish dry_run=False
2025-01-28 09:51:02,872 readfish experiment_name='deez'
2025-01-28 09:51:02,872 readfish host='127.0.0.1'
2025-01-28 09:51:02,872 readfish log_file=None
2025-01-28 09:51:02,872 readfish log_format='%(asctime)s %(name)s %(message)s'
2025-01-28 09:51:02,872 readfish log_level='info'
2025-01-28 09:51:02,872 readfish max_unblock_read_length_seconds=5
2025-01-28 09:51:02,872 readfish port=None
2025-01-28 09:51:02,872 readfish throttle=0.4
2025-01-28 09:51:02,872 readfish unblock_duration=0.1
2025-01-28 09:51:02,872 readfish wait_for_ready=120
2025-01-28 09:51:02,872 readfish Version=2024.3.0
2025-01-28 09:51:02,930 readfish.unblock-all This readfish version (2024.3.0) is tested for compatibility with MinKNOW v6.0.0 to v6.0.0.
This version of minknow is 6.2.8.
If readfish fails please try to upgrade readfish.
If there isn't a newer version of readfish and readfish is failing, please open an issue:
    https://github.com/LooseLab/readfish/issues
2025-01-28 09:51:02,954 readfish._read_until_client Got RPC exception
<_InactiveRpcError of RPC that terminated with:
	status = StatusCode.FAILED_PRECONDITION
	details = "No protocol running"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:8000 {grpc_message:"No protocol running", grpc_status:9, created_time:"2025-01-28T09:51:02.95323+00:00"}"
>
2025-01-28 09:51:02,954 readfish._read_until_client No protocol running, Run is currently not underway, Please check MinKNOW UI.
```

We still need to error log the missing strands before we release this change I think, in case that is changed upstream in MinKNOW.