### PR TITLE
fix no reads in RNA004

### DIFF
--- a/src/readfish/entry_points/targets.py
+++ b/src/readfish/entry_points/targets.py
@@ -613,6 +613,17 @@ If there isn't a newer version of readfish and readfish is failing, please open 
 
     # Fetch sequencing device
     position = get_device(args.device, host=args.host, port=args.port)
+    flowcell_type = position.connect().protocol.get_run_info().flow_cell.user_specified_product_code
+
+    base_classes = {"strand", "adapter", "unknown_positive"}
+
+    if flowcell_type in ['FLO-MIN004RA', 'FLO-PRO004RA']:
+        prefilter_classes = base_classes
+        accepted_first_chunk_classifications = list(base_classes)
+    else:
+        extended_classes = base_classes | {"strand2", "short_strand"}
+        prefilter_classes = extended_classes
+        accepted_first_chunk_classifications = list(extended_classes)
 
     # Create a read until client
     read_until_client = RUClient(
@@ -621,13 +632,7 @@ If there isn't a newer version of readfish and readfish is failing, please open 
         filter_strands=True,
         cache_type=AccumulatingCache,
         timeout=args.wait_for_ready,
-        prefilter_classes={
-            "strand",
-            "strand2",
-            "short_strand",
-            "adapter",
-            "unknown_positive",
-        },
+        prefilter_classes=prefilter_classes,
     )
 
     # Load TOML configuration
@@ -652,13 +657,7 @@ If there isn't a newer version of readfish and readfish is failing, please open 
         first_channel=1,
         last_channel=read_until_client.channel_count,
         max_unblock_read_length_seconds=args.max_unblock_read_length_seconds,
-        accepted_first_chunk_classifications=[
-            "strand",
-            "strand2",
-            "short_strand",
-            "adapter",
-            "unknown_positive",
-        ],
+        accepted_first_chunk_classifications=accepted_first_chunk_classifications,
     )
 
     worker = Analysis(


### PR DESCRIPTION
Adding fix for adaptive sampling on direct RNA sequencing (RNA004). The fix will use `flow_cell.user_specified_product_code` from run info to determine correct chunk classifications.

For direct RNA run the following classification is required: "strand", "adapter", "unknown_positive" (similar to old classification).

Running readfish with RNA004 playback. RU will not receive any reads.
```
2025-08-05 10:46:15,666 readfish.unblock-all Initialising Aligner
2025-08-05 10:46:15,666 readfish.unblock-all Aligner initialised
2025-08-05 10:46:15,675 readfish.unblock-all Starting main loop
2025-08-05 10:46:15,675 readfish.unblock-all Generating aligner description, if possible...
2025-08-05 10:46:15,675 readfish.unblock-all Using the `no_op` Aligner. No alignments will be performed, and all Results will be passed through.
2025-08-05 10:46:15,676 readfish.unblock-all readfish started in PHASE_SEQUENCING. Fully sequencing first read from each channel.
```

Running readfish with RNA004 playback. RU receive any reads.
```
2025-08-05 10:46:34,842 readfish.unblock-all readfish started in PHASE_SEQUENCING. Fully sequencing first read from each channel.
2025-08-05 10:46:36,078 readfish.unblock-all 0088R/0.0233s; Avg: 0088R/0.0233s; Seq:88; Unb:0; Pro:0; Slow batches (>1.00s): 0/1
2025-08-05 10:46:36,463 readfish.unblock-all 0009R/0.0030s; Avg: 0048R/0.0132s; Seq:97; Unb:0; Pro:0; Slow batches (>1.00s): 0/2
2025-08-05 10:46:36,867 readfish.unblock-all 0002R/0.0010s; Avg: 0033R/0.0091s; Seq:99; Unb:0; Pro:0; Slow batches (>1.00s): 0/3
```

Information
- tested for playback generated from two different experiment (MinION)
- should also work for PromethION

This is fix for reported issue below
- https://github.com/LooseLab/readfish/issues/394
